### PR TITLE
fix: protect the text of textfield from jumping after first edit

### DIFF
--- a/DJTableViewVM/Classes/AdvanceCells/InputCells/DJTableViewVMTextFieldCell.m
+++ b/DJTableViewVM/Classes/AdvanceCells/InputCells/DJTableViewVMTextFieldCell.m
@@ -182,6 +182,7 @@
     if (self.rowVM.didEndEditing) {
         self.rowVM.didEndEditing(self.rowVM);
     }
+    [textField layoutIfNeeded];
 }
 
 //note:called in place of textFieldDidEndEditing:
@@ -194,6 +195,7 @@
     if (self.rowVM.didEndEditing) {
         self.rowVM.didEndEditing(self.rowVM);
     }
+    [textField layoutIfNeeded];
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string


### PR DESCRIPTION
![test](https://user-images.githubusercontent.com/5327194/32365371-a3eff008-c047-11e7-91c9-7e40d51eefda.gif)
